### PR TITLE
redesign: Modify flex property css for album list

### DIFF
--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -38,9 +38,10 @@ const StyledAlbumItem = styled.div`
 
 const ImageContainer = styled.div`
   box-sizing: content-box;
-  padding: 0 ${(props) => props.theme.gutter.size20};
+  padding: ${(props) => `${props.theme.gutter.size8} ${props.theme.gutter.size20}`};
   width: 14rem;
-  height: 12rem;
+  height: 14rem;
+  flex-shrink: 0;
   border-right: 0.1rem solid ${(props) => props.theme.color.black};
 `;
 
@@ -57,8 +58,8 @@ const Info = styled.div`
 `;
 
 const Headline = styled.p`
+  flex: 0 0 12rem;
   font-size: ${(props) => props.theme.font.size80};
-  margin-right: ${(props) => props.theme.gutter.size56};
 `;
 
 const Title = styled.h2`


### PR DESCRIPTION
### Related to Any Issues?
- 브라우저를 줄였을때 앨범 이미지 가로가 줄어드는 이슈

### What's Changed?
- flexgrow, flexshrink 등의 값 수정
- 앨범 이미지 사이 padding 추가

### Any Screenshots?
<img width="1660" alt="Screen Shot 2022-04-18 at 8 18 56 PM" src="https://user-images.githubusercontent.com/46391618/163800993-20ba9765-3254-4e0f-80e8-70ffc9da9a5e.png">

