### PR TITLE
redesign:  tracklist 가 오픈되었을때 디자인 개발

### DIFF
--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -6,7 +6,7 @@ export const trackListState = atom<Track[]>({
   default: [],
 });
 
-export const currentOpenIndexState = atom<number>({
+export const currentOpenIndexState = atom<number | null>({
   key: 'currentOpenIndex',
-  default: 0,
+  default: null,
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -6,7 +6,7 @@ export const trackListState = atom<Track[]>({
   default: [],
 });
 
-export const currentOpenAlbumState = atom<number>({
-  key: 'currentOpenAlbum',
+export const currentOpenIndexState = atom<number>({
+  key: 'currentOpenIndex',
   default: 0,
 });

--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -47,8 +47,8 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
   }, [isItemOpen]);
 
   return (
-    <StyledAlbumItem>
-      <ImageContainer>
+    <StyledAlbumItem isItemOpen={isItemOpen}>
+      <ImageContainer isItemOpen={isItemOpen}>
         <DynamicImage images={images} />
       </ImageContainer>
       <AlbumDesc onClick={() => onOpenTrackList(index)}>
@@ -62,19 +62,24 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
   );
 };
 
-const StyledAlbumItem = styled.div`
+interface isItemOpenProps {
+  isItemOpen: boolean;
+}
+
+const StyledAlbumItem = styled.div<isItemOpenProps>`
   display: flex;
+  flex-direction: ${({ isItemOpen }) => (isItemOpen ? 'column-reverse' : 'row')};
   width: 100%;
   font-weight: 700;
 `;
 
-const ImageContainer = styled.div`
+const ImageContainer = styled.div<isItemOpenProps>`
   box-sizing: content-box;
   padding: ${(props) => `${props.theme.gutter.size8} ${props.theme.gutter.size20}`};
-  width: 14rem;
-  height: 14rem;
   flex-shrink: 0;
-  border-right: 0.1rem solid ${(props) => props.theme.color.black};
+  width: ${({ isItemOpen }) => (isItemOpen ? '30rem' : '14rem')};
+  height: ${({ isItemOpen }) => (isItemOpen ? '30rem' : '14rem')};
+  border-right: ${({ theme, isItemOpen }) => !isItemOpen && `0.1rem solid ${theme.color.black}`};
 `;
 
 const AlbumDesc = styled.div`

--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -18,15 +18,21 @@ interface AlbumItemProps {
 const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps): JSX.Element => {
   const [currentOpenIndex, setCurrentOpenIndex] = useRecoilState<number>(currentOpenIndexState);
   const [trackList, setTrackList] = useRecoilState<Track[]>(trackListState);
-  const [isItemOpen, setIsItemOpen] = useState(false);
+  const [isCurrentOpen, setIsCurrentOpen] = useState(false);
 
   const onOpenTrackList = (index: number) => {
     setCurrentOpenIndex(index);
   };
 
   useEffect(() => {
+    if (!currentOpenIndex) return;
+
+    setIsCurrentOpen(currentOpenIndex === index);
+  }, [currentOpenIndex]);
+
+  useEffect(() => {
+    if (!isCurrentOpen) return;
     const getTrackListData = async () => {
-      if (!isItemOpen) return;
       try {
         const trackListData = await getAxiosData<Track[]>({
           url: `/albums/${id}`,
@@ -42,26 +48,15 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
     };
 
     getTrackListData();
-  }, [currentOpenIndex]);
-
-  useEffect(() => {
-    if (!currentOpenIndex) return;
-
-    setIsItemOpen(true);
-  }, [currentOpenIndex]);
-
-  const openHandler = (index: number): boolean => {
-    return currentOpenIndex === index && isItemOpen;
-  };
+  }, [isCurrentOpen]);
 
   return (
-    <StyledAlbumItem isItemOpen={openHandler(index)}>
-      <TrackContainer isItemOpen={openHandler(index)}>
-        currentOpenIndex:{currentOpenIndex}
-        <ImageContainer isItemOpen={openHandler(index)}>
+    <StyledAlbumItem isCurrentOpen={isCurrentOpen}>
+      <TrackContainer isCurrentOpen={isCurrentOpen}>
+        <ImageContainer isCurrentOpen={isCurrentOpen}>
           <DynamicImage images={images} />
         </ImageContainer>
-        {openHandler(index) && <TrackList key={`track-list-${index}`} />}
+        {isCurrentOpen && <TrackList key={`track-list-${index}`} />}
       </TrackContainer>
       <AlbumDesc onClick={() => onOpenTrackList(index)}>
         <Headline>{count}</Headline>
@@ -74,29 +69,29 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
   );
 };
 
-interface isItemOpenProps {
-  isItemOpen: boolean;
+interface isCurrentOpenProps {
+  isCurrentOpen: boolean;
 }
 
-const StyledAlbumItem = styled.div<isItemOpenProps>`
+const StyledAlbumItem = styled.div<isCurrentOpenProps>`
   display: flex;
-  flex-direction: ${({ isItemOpen }) => (isItemOpen ? 'column-reverse' : 'row')};
+  flex-direction: ${({ isCurrentOpen }) => (isCurrentOpen ? 'column-reverse' : 'row')};
   width: 100%;
   font-weight: 700;
 `;
 
-const TrackContainer = styled.div<isItemOpenProps>`
+const TrackContainer = styled.div<isCurrentOpenProps>`
   display: flex;
   flex-direction: row;
 `;
 
-const ImageContainer = styled.div<isItemOpenProps>`
+const ImageContainer = styled.div<isCurrentOpenProps>`
   box-sizing: content-box;
   padding: ${(props) => `${props.theme.gutter.size8} ${props.theme.gutter.size20}`};
   flex-shrink: 0;
-  width: ${({ isItemOpen }) => (isItemOpen ? '30rem' : '14rem')};
-  height: ${({ isItemOpen }) => (isItemOpen ? '30rem' : '14rem')};
-  border-right: ${({ theme, isItemOpen }) => !isItemOpen && `0.1rem solid ${theme.color.black}`};
+  width: ${({ isCurrentOpen }) => (isCurrentOpen ? '30rem' : '14rem')};
+  height: ${({ isCurrentOpen }) => (isCurrentOpen ? '30rem' : '14rem')};
+  border-right: ${({ theme, isCurrentOpen }) => !isCurrentOpen && `0.1rem solid ${theme.color.black}`};
 `;
 
 const AlbumDesc = styled.div`

--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -20,20 +20,13 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
   const [trackList, setTrackList] = useRecoilState<Track[]>(trackListState);
   const [isItemOpen, setIsItemOpen] = useState(false);
 
-  const initOpenList = () => {
-    setIsItemOpen(false);
-  };
-
   const onOpenTrackList = (index: number) => {
-    initOpenList();
-    setIsItemOpen(true);
     setCurrentOpenIndex(index);
   };
 
   useEffect(() => {
     const getTrackListData = async () => {
       if (!isItemOpen) return;
-
       try {
         const trackListData = await getAxiosData<Track[]>({
           url: `/albums/${id}`,
@@ -49,15 +42,26 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
     };
 
     getTrackListData();
-  }, [isItemOpen]);
+  }, [currentOpenIndex]);
+
+  useEffect(() => {
+    if (!currentOpenIndex) return;
+
+    setIsItemOpen(true);
+  }, [currentOpenIndex]);
+
+  const openHandler = (index: number): boolean => {
+    return currentOpenIndex === index && isItemOpen;
+  };
 
   return (
-    <StyledAlbumItem isItemOpen={isItemOpen}>
-      <TrackContainer isItemOpen={isItemOpen}>
-        <ImageContainer isItemOpen={isItemOpen}>
+    <StyledAlbumItem isItemOpen={openHandler(index)}>
+      <TrackContainer isItemOpen={openHandler(index)}>
+        currentOpenIndex:{currentOpenIndex}
+        <ImageContainer isItemOpen={openHandler(index)}>
           <DynamicImage images={images} />
         </ImageContainer>
-        {isItemOpen && currentOpenIndex === index && <TrackList key={`track-list-${index}`} />}
+        {openHandler(index) && <TrackList key={`track-list-${index}`} />}
       </TrackContainer>
       <AlbumDesc onClick={() => onOpenTrackList(index)}>
         <Headline>{count}</Headline>

--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -32,6 +32,7 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
 
   useEffect(() => {
     if (!isCurrentOpen) return;
+
     const getTrackListData = async () => {
       try {
         const trackListData = await getAxiosData<Track[]>({
@@ -47,7 +48,11 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
       }
     };
 
-    getTrackListData();
+    try {
+      getTrackListData();
+    } catch (err) {
+      console.error(err);
+    }
   }, [isCurrentOpen]);
 
   return (

--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -3,9 +3,9 @@ import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import DynamicImage from './common/DynamicImage';
 import { AlbumImage, Track } from '@/types/common';
-import { currentOpenAlbumState, trackListState } from '@/atoms/index';
+import { currentOpenIndexState, trackListState } from '@/atoms/index';
 import { getAxiosData } from '@/utils/index';
-
+import TrackList from '@/components/TrackList';
 interface AlbumItemProps {
   id: string;
   index: number;
@@ -16,13 +16,18 @@ interface AlbumItemProps {
 }
 
 const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps): JSX.Element => {
-  const [currentOpenAlbum, setCurrentOpenAlbum] = useRecoilState<number>(currentOpenAlbumState);
+  const [currentOpenIndex, setCurrentOpenIndex] = useRecoilState<number>(currentOpenIndexState);
   const [trackList, setTrackList] = useRecoilState<Track[]>(trackListState);
   const [isItemOpen, setIsItemOpen] = useState(false);
 
+  const initOpenList = () => {
+    setIsItemOpen(false);
+  };
+
   const onOpenTrackList = (index: number) => {
-    setIsItemOpen(!isItemOpen);
-    setCurrentOpenAlbum(index);
+    initOpenList();
+    setIsItemOpen(true);
+    setCurrentOpenIndex(index);
   };
 
   useEffect(() => {
@@ -48,9 +53,12 @@ const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps):
 
   return (
     <StyledAlbumItem isItemOpen={isItemOpen}>
-      <ImageContainer isItemOpen={isItemOpen}>
-        <DynamicImage images={images} />
-      </ImageContainer>
+      <TrackContainer isItemOpen={isItemOpen}>
+        <ImageContainer isItemOpen={isItemOpen}>
+          <DynamicImage images={images} />
+        </ImageContainer>
+        {isItemOpen && currentOpenIndex === index && <TrackList key={`track-list-${index}`} />}
+      </TrackContainer>
       <AlbumDesc onClick={() => onOpenTrackList(index)}>
         <Headline>{count}</Headline>
         <Info>
@@ -71,6 +79,11 @@ const StyledAlbumItem = styled.div<isItemOpenProps>`
   flex-direction: ${({ isItemOpen }) => (isItemOpen ? 'column-reverse' : 'row')};
   width: 100%;
   font-weight: 700;
+`;
+
+const TrackContainer = styled.div<isItemOpenProps>`
+  display: flex;
+  flex-direction: row;
 `;
 
 const ImageContainer = styled.div<isItemOpenProps>`

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -52,6 +52,10 @@ const StyledAlbumList = styled.div`
   display: flex;
   flex-direction: column;
   flex-basis: 70%;
+
+  li:not(:last-child) {
+    border-bottom: 0.1rem solid pink;
+  }
 `;
 
 export default AlbumList;

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 import AlbumItem from '@/components/AlbumItem';
 import { getAxiosData } from '@/utils/index';
 import { Album } from '@/types/common';
-import { currentOpenAlbumState } from '@/atoms/index';
-import TrackList from './TrackList';
+// import { currentOpenIndexState } from '@/atoms/index';
+// import TrackList from './TrackList';
 import { useRecoilValue } from 'recoil';
 
 const AlbumList = (): JSX.Element => {
   const [albumList, setAlbumList] = useState<Album[]>([]);
-  const currentOpenAlbum = useRecoilValue(currentOpenAlbumState);
+  // const currentOpenIndex = useRecoilValue(currentOpenIndexState);
 
   useEffect(() => {
     const getAlbumListData = async () => {
@@ -41,7 +41,6 @@ const AlbumList = (): JSX.Element => {
               artist={item.artists[0].name}
               images={item.images}
             />
-            {currentOpenAlbum === index && <TrackList key={`track-list-${index}`} />}
           </Fragment>
         ))}
     </StyledAlbumList>

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -3,13 +3,9 @@ import styled from 'styled-components';
 import AlbumItem from '@/components/AlbumItem';
 import { getAxiosData } from '@/utils/index';
 import { Album } from '@/types/common';
-// import { currentOpenIndexState } from '@/atoms/index';
-// import TrackList from './TrackList';
-import { useRecoilValue } from 'recoil';
 
 const AlbumList = (): JSX.Element => {
   const [albumList, setAlbumList] = useState<Album[]>([]);
-  // const currentOpenIndex = useRecoilValue(currentOpenIndexState);
 
   useEffect(() => {
     const getAlbumListData = async () => {
@@ -21,7 +17,6 @@ const AlbumList = (): JSX.Element => {
         },
       });
 
-      console.log(albumListData);
       setAlbumList(albumListData);
     };
     getAlbumListData();
@@ -52,8 +47,12 @@ const StyledAlbumList = styled.div`
   flex-direction: column;
   flex-basis: 70%;
 
-  li:not(:last-child) {
-    border-bottom: 0.1rem solid pink;
+  li {
+    padding: 0.2rem 0;
+
+    &:not(:last-child) {
+      border-bottom: 0.1rem solid ${({ theme }) => theme.color.black};
+    }
   }
 `;
 

--- a/src/components/TrackItem.tsx
+++ b/src/components/TrackItem.tsx
@@ -5,8 +5,8 @@ const TrackItem = ({ name }: { name: string }) => {
   return <StyledTrackItem>{name}</StyledTrackItem>;
 };
 
-const StyledTrackItem = styled.div`
-  border-bottom: 0.1rem solid ${(props) => props.theme.color.black};
+const StyledTrackItem = styled.li`
+  font-size: 2rem;
 `;
 
 export default TrackItem;

--- a/src/components/TrackList.tsx
+++ b/src/components/TrackList.tsx
@@ -15,7 +15,7 @@ const TrackList = () => {
 
 const StyledTrackList = styled.ul`
   width: 100%;
-  border: 1px solid blue;
+  padding: ${({ theme }) => theme.gutter.size12} 0;
 `;
 
 export default TrackList;

--- a/src/components/TrackList.tsx
+++ b/src/components/TrackList.tsx
@@ -13,8 +13,9 @@ const TrackList = () => {
   );
 };
 
-const StyledTrackList = styled.div`
-  border-bottom: 0.1rem solid ${(props) => props.theme.color.black};
+const StyledTrackList = styled.ul`
+  width: 100%;
+  border: 1px solid blue;
 `;
 
 export default TrackList;


### PR DESCRIPTION
### Related to Any Issues?
- 
### What's Changed?
- tracklist 컴포넌트를 albumItem 내부로 이동
- 오픈되었을때 디자인 변경 

### Any Screenshot?
<img width="1122" alt="Screen Shot 2022-04-20 at 12 33 39 AM" src="https://user-images.githubusercontent.com/46391618/164041118-f11339f0-56ee-4773-bf05-5136b2b227db.png">

### TODO
- currentOpenIndex 가 store로 관리될 필요가 없어서 변경 필요

