### PR TITLE
fix: 트랙리스트가 업데이트 되기 이전에 UI가 오픈되는 버그

### DIFF
--- a/src/components/AlbumItem.tsx
+++ b/src/components/AlbumItem.tsx
@@ -16,50 +16,36 @@ interface AlbumItemProps {
   title: string;
   artist: string;
   images: AlbumImage[];
+  isCurrentOpen: boolean;
 }
 
-const AlbumItem = ({ id, index, count, title, artist, images }: AlbumItemProps): JSX.Element => {
-  const [currentOpenIndex, setCurrentOpenIndex] = useRecoilState<number>(currentOpenIndexState);
+const AlbumItem = ({ id, index, count, title, artist, images, isCurrentOpen }: AlbumItemProps): JSX.Element => {
   const [trackList, setTrackList] = useRecoilState<Track[]>(trackListState);
-  const [isCurrentOpen, setIsCurrentOpen] = useState(false);
+  const [currentOpenIndex, setCurrentOpenIndex] = useRecoilState<number>(currentOpenIndexState);
 
-  const onOpenTrackList = (index: number) => {
-    setCurrentOpenIndex(index);
-  };
-
-  useEffect(() => {
-    if (currentOpenIndex === null) return;
-    setIsCurrentOpen(currentOpenIndex === index);
-  }, [currentOpenIndex]);
-
-  useEffect(() => {
-    if (!isCurrentOpen) return;
-
-    const getTrackListData = async () => {
-      try {
-        const trackListData = await getAxiosData<Track[]>({
-          url: `/albums/${id}`,
-          key: 'tracks',
-          params: {
-            market: 'KR',
-          },
-        });
-        setTrackList(trackListData);
-      } catch (err) {
-        console.error(err);
-      }
-    };
-
+  const getTrackListData = async () => {
     try {
-      getTrackListData();
+      const trackListData = await getAxiosData<Track[]>({
+        url: `/albums/${id}`,
+        key: 'tracks',
+        params: {
+          market: 'KR',
+        },
+      });
+      setTrackList(trackListData);
     } catch (err) {
       console.error(err);
     }
-  }, [isCurrentOpen]);
+  };
+
+  const onOpenTrackList = async (index: number) => {
+    await getTrackListData();
+    setCurrentOpenIndex(index);
+  };
 
   return (
     <StyledAlbumItem isCurrentOpen={isCurrentOpen}>
-      <TrackContainer isCurrentOpen={isCurrentOpen}>
+      <TrackContainer>
         <ImageContainer isCurrentOpen={isCurrentOpen}>
           <DynamicImage images={images} />
         </ImageContainer>
@@ -91,7 +77,7 @@ const StyledAlbumItem = styled.div<isCurrentOpenProps>`
   font-weight: 700;
 `;
 
-const TrackContainer = styled.div<isCurrentOpenProps>`
+const TrackContainer = styled.div`
   display: flex;
   flex-direction: row;
 `;

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -1,42 +1,64 @@
 import React, { Fragment, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import AlbumItem from '@/components/AlbumItem';
+import { currentOpenIndexState } from '@/atoms/index';
 import { getAxiosData } from '@/utils/index';
 import { Album } from '@/types/common';
+import { useRecoilState } from 'recoil';
 
 const AlbumList = (): JSX.Element => {
   const [albumList, setAlbumList] = useState<Album[]>([]);
+  const [currentOpenIndex, setCurrentOpenIndex] = useRecoilState<number>(currentOpenIndexState);
+
+  const getAlbumListData = async () => {
+    const data = await getAxiosData<Album[]>({
+      url: '/browse/new-releases',
+      key: 'albums',
+      params: {
+        country: 'KR',
+      },
+    });
+
+    setAlbumList(
+      data.map((item) => {
+        return {
+          ...item,
+          isCurrentOpen: false,
+        };
+      })
+    );
+  };
 
   useEffect(() => {
-    const getAlbumListData = async () => {
-      const albumListData = await getAxiosData<Album[]>({
-        url: '/browse/new-releases',
-        key: 'albums',
-        params: {
-          country: 'KR',
-        },
-      });
-
-      setAlbumList(albumListData);
-    };
     getAlbumListData();
   }, []);
+
+  useEffect(() => {
+    if (!albumList.length) return;
+    const newList = albumList.map((item, index) => {
+      if (index === currentOpenIndex) {
+        return { ...albumList[currentOpenIndex], isCurrentOpen: true };
+      }
+      return { ...item, isCurrentOpen: false };
+    });
+
+    setAlbumList(newList);
+  }, [currentOpenIndex]);
 
   return (
     <StyledAlbumList>
       {albumList.length > 0 &&
         albumList.map((item, index) => (
-          <Fragment key={`album-item-${item.id}`}>
-            <AlbumItem
-              key={`album-item-${item.id}`}
-              id={item.id}
-              index={index}
-              count={index + 1}
-              title={item.name}
-              artist={item.artists[0].name}
-              images={item.images}
-            />
-          </Fragment>
+          <AlbumItem
+            key={`album-item-${item.id}`}
+            id={item.id}
+            index={index}
+            count={index + 1}
+            title={item.name}
+            artist={item?.artists[0]?.name}
+            images={item.images}
+            isCurrentOpen={item.isCurrentOpen}
+          />
         ))}
     </StyledAlbumList>
   );

--- a/src/components/AlbumList.tsx
+++ b/src/components/AlbumList.tsx
@@ -4,11 +4,11 @@ import AlbumItem from '@/components/AlbumItem';
 import { currentOpenIndexState } from '@/atoms/index';
 import { getAxiosData } from '@/utils/index';
 import { Album } from '@/types/common';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 const AlbumList = (): JSX.Element => {
   const [albumList, setAlbumList] = useState<Album[]>([]);
-  const [currentOpenIndex, setCurrentOpenIndex] = useRecoilState<number>(currentOpenIndexState);
+  const currentOpenIndex = useRecoilValue<number>(currentOpenIndexState);
 
   const getAlbumListData = async () => {
     const data = await getAxiosData<Album[]>({

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,6 +22,7 @@ export interface Album {
   images: AlbumImage[];
   total_tracks: number;
   tracks: Track[];
+  isCurrentOpen: boolean;
 }
 
 export interface Track {


### PR DESCRIPTION
### Related to Any Issues?
- 트랙리스트가 업데이트 되기 이전에 UI가 오픈되는 문제
### What's Changed?
- isCurrentOpen을 AlbumItem 내에서 관리 -> AlbumList 에서 map으로 관리하여 내려주는 방향으로 변경
- useEffect 를 사용하지 않고 click 이벤트를 받았을때 getTrackList 를 호출하도록 변경
- `await getTrackListData();` 후에 currentOpenIndex 를 업데이트하도록 변경

### Any Screenshot?

https://user-images.githubusercontent.com/46391618/164968165-d7453dba-bbe3-42b7-a0af-24834c59748e.mov



